### PR TITLE
Fix error when getting list of servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "schedule": "^0.1.0",
-    "speedtest-net": "^0.1.2",
+    "speedtest-net": "^1.2.7",
     "twit": "^1.1.18",
     "yargs": "^1.3.3"
   }


### PR DESCRIPTION
By upgrading the package we can get rid of this error message:

running test
events.js:141
      throw er; // Unhandled 'error' event
      ^

TypeError: Cannot read property 'servers' of undefined
    at gotServers (C:\src\pj\speed-and-tweet\node_modules\speedtest-net\index.js:423:27)
    at C:\src\pj\speed-and-tweet\node_modules\speedtest-net\index.js:40:16
    at C:\src\pj\speed-and-tweet\node_modules\speedtest-net\index.js:215:7
    at Parser.<anonymous> (C:\src\pj\speed-and-tweet\node_modules\xml2js\lib\xml2js.js:489:18)
    at emitOne (events.js:77:13)
    at Parser.emit (events.js:169:7)
    at Object.onclosetag (C:\src\pj\speed-and-tweet\node_modules\xml2js\lib\xml2js.js:447:26)
    at emit (C:\src\pj\speed-and-tweet\node_modules\sax\lib\sax.js:640:35)
    at emitNode (C:\src\pj\speed-and-tweet\node_modules\sax\lib\sax.js:645:5)
    at closeTag (C:\src\pj\speed-and-tweet\node_modules\sax\lib\sax.js:905:7)
